### PR TITLE
Windows build fix + CI

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -15,7 +15,7 @@ jobs:
   build-and-test:
     strategy:
       matrix:
-        os: [ubuntu-latest, macos-latest]
+        os: [ubuntu-latest, macos-latest, windows-latest]
     runs-on: ${{ matrix.os }}
 
     steps:
@@ -31,6 +31,7 @@ jobs:
         run: cargo test --verbose
 
       - name: Run cargo bench
+        if: matrix.os != 'windows-latest'
         run: cargo bench --verbose
 
       - name: Run cargo clippy (default)
@@ -40,7 +41,9 @@ jobs:
         run: cargo clippy --tests -- -D warnings
 
       - name: Run cargo clippy (bench bls381_benches)
+        if: matrix.os != 'windows-latest'
         run: cargo clippy --bench bls381_benches -- -D warnings
 
       - name: Run cargo clippy (bench multi_verify_benches)
+        if: matrix.os != 'windows-latest'
         run: cargo clippy --bench multi_verify_benches -- -D warnings

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -15,7 +15,7 @@ jobs:
   build-and-test:
     strategy:
       matrix:
-        os: [ubuntu-latest, macos-latest, windows-latest]
+        os: [ubuntu-latest, macos-latest]
     runs-on: ${{ matrix.os }}
 
     steps:
@@ -30,20 +30,59 @@ jobs:
       - name: Run cargo test
         run: cargo test --verbose
 
-      - name: Run cargo bench
-        if: matrix.os != 'windows-latest'
-        run: cargo bench --verbose
-
       - name: Run cargo clippy (default)
         run: cargo clippy -- -D warnings
 
       - name: Run cargo clippy (tests)
         run: cargo clippy --tests -- -D warnings
 
+  bench:
+    strategy:
+      matrix:
+        os: [ubuntu-latest, macos-latest]
+    runs-on: ${{ matrix.os }}
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          components: clippy
+
+      - name: Run cargo bench
+        run: cargo bench --verbose
+
       - name: Run cargo clippy (bench bls381_benches)
-        if: matrix.os != 'windows-latest'
         run: cargo clippy --bench bls381_benches -- -D warnings
 
       - name: Run cargo clippy (bench multi_verify_benches)
-        if: matrix.os != 'windows-latest'
         run: cargo clippy --bench multi_verify_benches -- -D warnings
+
+  build-and-test-windows:
+    runs-on: windows-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          components: clippy
+          targets: x86_64-pc-windows-gnu
+
+      - name: Add MinGW to PATH
+        shell: pwsh
+        run: echo "C:\msys64\mingw64\bin" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
+
+      - name: Run cargo test
+        env:
+          CARGO_BUILD_TARGET: x86_64-pc-windows-gnu
+        run: cargo test --verbose
+
+      - name: Run cargo clippy (tests)
+        env:
+          CARGO_BUILD_TARGET: x86_64-pc-windows-gnu
+        run: cargo clippy --tests -- -D warnings

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -78,11 +78,7 @@ jobs:
         run: echo "C:\msys64\mingw64\bin" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
 
       - name: Run cargo test
-        env:
-          CARGO_BUILD_TARGET: x86_64-pc-windows-gnu
-        run: cargo test --verbose
+        run: cargo test --target x86_64-pc-windows-gnu --verbose
 
       - name: Run cargo clippy (tests)
-        env:
-          CARGO_BUILD_TARGET: x86_64-pc-windows-gnu
-        run: cargo clippy --tests -- -D warnings
+        run: cargo clippy --tests --target x86_64-pc-windows-gnu -- -D warnings

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 target
 Cargo.lock
 CVS
+.DS_Store

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,8 +17,8 @@ categories = ["cryptography"]
 path = "src/lib.rs"
 
 [dependencies]
-criterion = "0.7.0"
-hex = "0.4.0"
+criterion = "0.8"
+hex = "0.4"
 
 [[bench]]
 name = "bls381_benches"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ categories = ["cryptography"]
 [lib]
 path = "src/lib.rs"
 
-[dependencies]
+[dev-dependencies]
 criterion = "0.8"
 hex = "0.4"
 

--- a/README.md
+++ b/README.md
@@ -162,7 +162,7 @@ let buffer = [0; 96];
 
 let mut public_key = G2::default();
 
-if !public_key.deserialize_g2(buffer) {
+if !public_key.deserialize_g2(&buffer) {
     return Err(BlsError::InvalidData);
 }
 ```
@@ -174,7 +174,7 @@ let buffer = [0; 48];
 
 let mut sign = G1::default();
 
-if !sign.deserialize(buffer) {
+if !sign.deserialize(&buffer) {
     return Err(BlsError::InvalidData);
 }
 ```

--- a/README.md
+++ b/README.md
@@ -186,3 +186,9 @@ fn verify_signature(signature: G1, public_key: G2, message: &[u8]) {
     signature.verify(public_key, message)
 }
 ```
+
+## Acknowledgements
+
+This repository originated as a fork of [herumi/bls-eth-rust](https://github.com/herumi/bls-eth-rust) by MITSUNARI Shigeo, a Rust wrapper around the [herumi/bls](https://github.com/herumi/bls) C library. The original implementation provided the foundational FFI bindings and BLS primitives that this library builds upon.
+
+The codebase has since been substantially rewritten — Ethereum-specific logic was removed, the API was restructured into dedicated modules, and the library was tailored to MultiversX's requirements. The fork has been detached from the upstream repository to reflect this divergence.

--- a/build.rs
+++ b/build.rs
@@ -26,6 +26,7 @@ fn main() {
         ("x86_64", "windows") => {
             println!("cargo:rustc-link-search=native=./executors");
             println!("cargo:rustc-link-lib=static=bls384_256_amd_windows");
+            println!("cargo:rustc-link-lib=advapi32");
             let env = std::env::var("CARGO_CFG_TARGET_ENV").unwrap_or_default();
             if env == "gnu" {
                 println!("cargo:rustc-link-lib=stdc++");

--- a/build.rs
+++ b/build.rs
@@ -23,9 +23,9 @@ fn main() {
             println!("cargo:rustc-link-lib=static=bls384_256_arm_macos");
             println!("cargo:rustc-link-lib=c++");
         }
-        (_, "windows") => {
+        ("x86_64", "windows") => {
             println!("cargo:rustc-link-search=native=./executors");
-            println!("cargo:rustc-link-lib=static=bls384_256_arm_macos");
+            println!("cargo:rustc-link-lib=static=bls384_256_amd_windows");
             println!("cargo:rustc-link-lib=stdc++");
         }
         _ => panic!("Unsupported target: {os}-{target}"),

--- a/build.rs
+++ b/build.rs
@@ -24,13 +24,18 @@ fn main() {
             println!("cargo:rustc-link-lib=c++");
         }
         ("x86_64", "windows") => {
+            let env = std::env::var("CARGO_CFG_TARGET_ENV").unwrap_or_default();
+            if env == "msvc" {
+                panic!(
+                    "The x86_64-pc-windows-msvc target is not supported: only a MinGW/GNU-compatible \
+                     static archive is provided. Use the x86_64-pc-windows-gnu target instead, or \
+                     supply an MSVC-compatible import/static library."
+                );
+            }
             println!("cargo:rustc-link-search=native=./executors");
             println!("cargo:rustc-link-lib=static=bls384_256_amd_windows");
             println!("cargo:rustc-link-lib=advapi32");
-            let env = std::env::var("CARGO_CFG_TARGET_ENV").unwrap_or_default();
-            if env == "gnu" {
-                println!("cargo:rustc-link-lib=stdc++");
-            }
+            println!("cargo:rustc-link-lib=stdc++");
         }
         _ => panic!("Unsupported target: {os}-{target}"),
     }

--- a/build.rs
+++ b/build.rs
@@ -26,6 +26,10 @@ fn main() {
         ("x86_64", "windows") => {
             println!("cargo:rustc-link-search=native=./executors");
             println!("cargo:rustc-link-lib=static=bls384_256_amd_windows");
+            let env = std::env::var("CARGO_CFG_TARGET_ENV").unwrap_or_default();
+            if env == "gnu" {
+                println!("cargo:rustc-link-lib=stdc++");
+            }
         }
         _ => panic!("Unsupported target: {os}-{target}"),
     }

--- a/build.rs
+++ b/build.rs
@@ -26,7 +26,6 @@ fn main() {
         ("x86_64", "windows") => {
             println!("cargo:rustc-link-search=native=./executors");
             println!("cargo:rustc-link-lib=static=bls384_256_amd_windows");
-            println!("cargo:rustc-link-lib=stdc++");
         }
         _ => panic!("Unsupported target: {os}-{target}"),
     }


### PR DESCRIPTION
## Pull request overview

This PR aims to improve cross-platform reliability by fixing Windows linking behavior for the bundled native executor library and expanding CI coverage (separating benches and adding a Windows job).

**Changes:**
- Update `build.rs` Windows linking to use the Windows AMD64 static library and conditionally link `stdc++` only for the GNU environment.
- Restructure GitHub Actions CI by moving benches into a separate job and adding a Windows (GNU) build/test job.
- Bump dependency version requirements (`criterion`, `hex`) and add `.DS_Store` to `.gitignore`.
